### PR TITLE
Fix shepherd email link

### DIFF
--- a/pages/about.md
+++ b/pages/about.md
@@ -10,7 +10,7 @@ tags: [about, hello, 👋]
 
 My name is JeanHeyd Meneide. I am a Software Engineer and the Project Editor for ISO/IEC JTC1 SC22 WG14 - Programming Languages, C. I specialize in ergonomic library design and performance tuning. My favorite work includes programming that enables even the newest programmers to produce high-quality code that pushes them and others towards the pit of success.
 
-You can send inquiries for work to [Shepherd](shepherd@soasis.org) of Shepherd's Oasis!
+You can send inquiries for work to [Shepherd](mailto:shepherd@soasis.org) of Shepherd's Oasis!
 
 In my free time I try to write and draw, which has naturally led me to creating this place here! I'll be posting... well, anything and everything that comes to mind that I think might be worth sharing. Feel free to poke around and examine things!
 


### PR DESCRIPTION
While visiting [About page](https://thephd.github.io/about/), I just notice this `Shepherd` is an email instead of a hyperlink. Currently, it's https://thephd.github.io/about/shepherd@soasis.org on the page. With adding the `mailto:`, it should be able to render a proper mailto link for the mail.